### PR TITLE
Added 4096 as default rsa key size + reload instead of restart for nginx

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,8 @@ certbot_server: ""
 certbot_eab_kid: ""
 certbot_eab_hmac_key: ""
 
-certbot_post_hook: /etc/init.d/nginx restart
+certbot_post_hook: /etc/init.d/nginx reload
 
 certbot_uninstall: false
+
+certbot_rsa_key_size: 4096

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -24,6 +24,7 @@
         --eab-hmac-key {{ certbot_eab_hmac_key }}
         --domain {{ item }}
         --cert-name {{ item }}
+        --rsa-key-size {{ certbot_rsa_key_size }}
         --keep-until-expiring
     creates: "/etc/letsencrypt/live/{{ item }}"
   loop: "{{ certbot_vhosts }}"


### PR DESCRIPTION
certbot defaults for rsa-key-size is 2048, see:
```
security:
  Security parameters & server settings

  --rsa-key-size N      Size of the RSA key. (default: 2048)
  --key-type {rsa,ecdsa}
                        Type of generated private key. Only *ONE* per
                        invocation can be provided at this time. (default:
                        ecdsa)
```
better approach would be to get on 4096.

-----

changing certs works with reload nginx fine, so downtime gets minimized....